### PR TITLE
Modify access specifiers of members for vendor use

### DIFF
--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -731,7 +731,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
         }
     }
 
-    private RILRequest obtainRequest(int request, Message result, WorkSource workSource) {
+    protected RILRequest obtainRequest(int request, Message result, WorkSource workSource) {
         RILRequest rr = RILRequest.obtain(request, result, workSource);
         addRequest(rr);
         return rr;
@@ -744,7 +744,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
         return rr;
     }
 
-    private void handleRadioProxyExceptionForRR(RILRequest rr, String caller, Exception e) {
+    protected void handleRadioProxyExceptionForRR(RILRequest rr, String caller, Exception e) {
         riljLoge(caller + ": " + e);
         resetProxyAndRequestList();
     }
@@ -5030,7 +5030,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
     }
 
     /** Converts from AccessNetworkType in frameworks to RadioAccessNetworks in HAL. */
-    private static int convertAntToRan(int accessNetworkType) {
+    protected static int convertAntToRan(int accessNetworkType) {
         switch (accessNetworkType) {
             case AccessNetworkType.GERAN:
                 return RadioAccessNetworks.GERAN;
@@ -6015,7 +6015,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
     }
 
     @UnsupportedAppUsage
-    static String requestToString(int request) {
+    protected static String requestToString(int request) {
         switch(request) {
             case RIL_REQUEST_GET_SIM_STATUS:
                 return "GET_SIM_STATUS";

--- a/src/java/com/android/internal/telephony/RILRequest.java
+++ b/src/java/com/android/internal/telephony/RILRequest.java
@@ -211,7 +211,7 @@ public class RILRequest {
     }
 
     @UnsupportedAppUsage
-    String serialString() {
+    public String serialString() {
         //Cheesy way to do %04d
         StringBuilder sb = new StringBuilder(8);
         String sn;


### PR DESCRIPTION
Change access specifier to 'protected' for members to be used in vendor
telephony framework.

orges: fixes manual network selection with R qti-telephony-common on
aosp

error: E/AndroidRuntime(14388): java.lang.IllegalAccessError: Method 'com.android.internal.telephony.RILRequest com.android.internal.telephony.RIL.obtainRequest(int, android.os.Message, android.os.WorkSource)' is inaccessible to class 'com.qualcomm.qti.internal.telephony.QtiRIL' (declaration of 'com.qualcomm.qti.internal.telephony.QtiRIL' appears in /system/system_ext/framework/qti-telephony-common.jar)

Change-Id: I729bd0c72f42871198547f68674bc4f55f2d5f25
CRs-Fixed: 2645142
Signed-off-by: orges <me@orgesified.ml>
Signed-off-by: Jabiyeff <cebiyevanar@gmail.com>