### PR TITLE
IMS: Fix incall MMI code failure after turning volte off

### DIFF
--- a/src/java/com/android/internal/telephony/GsmCdmaPhone.java
+++ b/src/java/com/android/internal/telephony/GsmCdmaPhone.java
@@ -1230,13 +1230,12 @@ public class GsmCdmaPhone extends Phone {
             return false;
         }
 
-        Phone imsPhone = mImsPhone;
-        if (imsPhone != null
-                && imsPhone.getServiceState().getState() == ServiceState.STATE_IN_SERVICE) {
-            return imsPhone.handleInCallMmiCommands(dialString);
-        }
-
         if (!isInCall()) {
+            Phone imsPhone = mImsPhone;
+            if (imsPhone != null
+                    && imsPhone.getServiceState().getState() == ServiceState.STATE_IN_SERVICE) {
+                return imsPhone.handleInCallMmiCommands(dialString);
+            }
             return false;
         }
 


### PR DESCRIPTION
When only Volte feature is turned off, device can register on
IMS for SMS service. In this case, calls are connected over CS.
If an incall MMI code is dialed, it is wrongly handled by
ImsPhone since IMS is in service and results in MMI code failure.
Avoid this by checking whether there are existing calls on CS
before invoking ImsPhone.

CRs-Fixed: 2872557
Change-Id: Ibd4b0bb6c6656ea956233edf29405708d80b2e76