### PR TITLE
Force Carrier Aggregation logic optimization

### DIFF
--- a/src/java/com/android/internal/telephony/ServiceStateTracker.java
+++ b/src/java/com/android/internal/telephony/ServiceStateTracker.java
@@ -140,6 +140,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import android.database.ContentObserver;
+import android.net.Uri;
+
 /**
  * {@hide}
  */
@@ -160,6 +163,12 @@ public class ServiceStateTracker extends Handler {
     private IccRecords mIccRecords = null;
 
     private boolean mVoiceCapable;
+
+    // Content observer for Force LTE_CA setting changes
+    private ContentObserver mForceLteCAObserver;
+
+    // Force LTE_CA state per SIM flag
+    private Boolean mForceLteCA = null;
 
     @UnsupportedAppUsage(maxTargetSdk = Build.VERSION_CODES.R, trackingBug = 170729553)
     public ServiceState mSS;
@@ -710,6 +719,9 @@ public class ServiceStateTracker extends Handler {
         mCi = ci;
         mFeatureFlags = featureFlags;
 
+        registerForceLteCAObserver();
+        updateForceLteCAState();
+
         mServiceStateStats = new ServiceStateStats(mPhone);
 
         mCdnr = new CarrierDisplayNameResolver(mPhone);
@@ -981,6 +993,12 @@ public class ServiceStateTracker extends Handler {
         if (mAccessNetworksManagerCallback != null) {
             mAccessNetworksManager.unregisterCallback(mAccessNetworksManagerCallback);
             mAccessNetworksManagerCallback = null;
+        }
+        // Unregister Force LTE_CA observer
+        if (mForceLteCAObserver != null) {
+            mPhone.getContext().getContentResolver()
+                    .unregisterContentObserver(mForceLteCAObserver);
+            mForceLteCAObserver = null;
         }
     }
 
@@ -3558,10 +3576,59 @@ public class ServiceStateTracker extends Handler {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Register content observer for Force LTE_CA setting changes.
+     */
+    private void registerForceLteCAObserver() {
+        int phoneId = mPhone.getPhoneId();
+        Uri settingUri = Settings.Global.getUriFor(
+                Settings.Global.FORCE_LTE_CA + "_" + phoneId);
+        
+        mForceLteCAObserver = new ContentObserver(this) {
+            @Override
+            public void onChange(boolean selfChange) {
+                if (DBG) log("Force LTE_CA setting changed, updating state");
+                updateForceLteCAState();
+            }
+        };
+        
+        mPhone.getContext().getContentResolver().registerContentObserver(
+                settingUri, false, mForceLteCAObserver);
+    }
+
+    /**
+     * Update the per-SIM Force LTE_CA flag and apply to ServiceState.
+     */
+    private void updateForceLteCAState() {
+        int phoneId = mPhone.getPhoneId();
+
+        int forceLteCAInt = Settings.Global.getInt(
+                mPhone.getContext().getContentResolver(),
+                Settings.Global.FORCE_LTE_CA + "_" + phoneId,
+                -1);
+
+        Boolean newForceLteCA = (forceLteCAInt == -1) ? null : (forceLteCAInt == 1);
+
+        if (!Objects.equals(mForceLteCA, newForceLteCA)) {
+            if (DBG) log("Force LTE_CA state changed from " + mForceLteCA + " to " + newForceLteCA);
+            
+            mForceLteCA = newForceLteCA;
+
+            if (mSS != null) {
+                mSS.setForceLteCA(newForceLteCA);
+                mPhone.notifyServiceStateChanged(mSS);
+            }
+
+            pollState();
+        }
+    }
+
     private void pollStateDone() {
         if (!mPhone.isPhoneTypeGsm()) {
             updateRoamingState();
         }
+
+        updateForceLteCAState();
 
         if (TelephonyUtils.IS_DEBUGGABLE
                 && SystemProperties.getBoolean(PROP_FORCE_ROAMING, false)) {
@@ -3806,6 +3873,9 @@ public class ServiceStateTracker extends Handler {
         }
 
         ServiceState oldMergedSS = new ServiceState(mPhone.getServiceState());
+
+        mNewSS.setForceLteCA(mForceLteCA);
+
         mSS = new ServiceState(mNewSS);
 
         mNewSS.setOutOfService(false);


### PR DESCRIPTION
Issue with commit:
[HACK: telephony: Conditionally force enable LTE_CA](https://github.com/crdroidandroid/android_frameworks_base/commit/a4025d81fb309560259ff3e953e770bdd861bf3f)

Reasons for reverting this commit:
----------------------------------
1. The commit forces Carrier Aggregation globally instead of per-SIM. Even though the setting is shown per-SIM in network options, the framework logic doesn't respect that. For example, enabling CA for SIM 2 also enables CA for SIM 1, which is incorrect and hacky behavior.

2. CA does not activate immediately because no ContentObserver is used. Users must restart mobile data for CA to apply, resulting in a poor user experience.

Improvements with the new commit:
Introduce Force LTE_CA override on a per-subscription basis
------------------------------------------------------------
1. Carrier Aggregation is now applied correctly per SIM. Enabling CA for SIM 2 affects only SIM 2 and does not affect SIM 1 unless the user enables it manually & vise versa.
2. A ContentObserver is implemented, allowing CA to apply instantly without requiring a mobile data restart.
3. The toggle has been renamed from "Force Carrier Aggregation" to "Carrier Aggregation" for better clarity and user control. Even if supported by hardware, users can now enable or disable it based on their preference.

This commit has been tested with Jio 4G and BSNL 4G networks:
-------------------------------------------------------------

Jio 4G:
In my locality, Jio automatically connects with LTE+ without using the Force Carrier Aggregation option. With this new commit, I can now enable or disable Carrier Aggregation whenever I want, giving full control over usage.

BSNL 4G:
In my area, BSNL does not achieve LTE+ by default unless Carrier Aggregation is forced. After enabling it using the new Carrier Aggregation toggle, LTE+ activates immediately without needing to restart mobile data.

![photo_6132005266581556036_y](https://github.com/user-attachments/assets/9de89bcb-ddf0-48cc-af1f-2e9379cc9165)

<img width="1080" height="2400" alt="Screenshot_20251126-134309" src="https://github.com/user-attachments/assets/64a87246-d3d6-405f-b32a-9c9a045e20ed" />
